### PR TITLE
Feat/Added password type and fixed warnings

### DIFF
--- a/example/src/forms.json
+++ b/example/src/forms.json
@@ -91,6 +91,18 @@
         }
       },
       {
+        "name": "password",
+        "type": "password",
+        "label": "Password",
+        "placeholder": "Password",
+        "errorMessages": {
+          "required": "This field is required"
+        },
+        "registerConfig": {
+          "required": true
+        }
+      },
+      {
         "name": "refrigerator_features",
         "type": "multiple_checkboxes",
         "label": "What features did you look for when buying your refrigerator? [MC, up to 10]",

--- a/src/Fields/Input/index.js
+++ b/src/Fields/Input/index.js
@@ -9,7 +9,7 @@ const Input = React.forwardRef(({ ...props }, ref) => {
     <InputUI
       ref={ref}
       {...props}
-      className={props.hasErrors && 'error-input'}
+      className={props.haserrors && 'error-input'}
     />
   )
 })

--- a/src/Fields/Select/index.js
+++ b/src/Fields/Select/index.js
@@ -14,9 +14,19 @@ const DropdownIndicator = (props) => {
     return (
       <components.DropdownIndicator {...props}>
         {menuIsOpen ? (
-          <Image src={up || down} width={width || 16} height={height || 16} />
+          <Image
+            alt='Select arrow up'
+            src={up || down}
+            width={width || 16}
+            height={height || 16}
+          />
         ) : (
-          <Image src={down || up} width={width || 16} height={height || 16} />
+          <Image
+            alt='Select arrow up'
+            src={down || up}
+            width={width || 16}
+            height={height || 16}
+          />
         )}
       </components.DropdownIndicator>
     )
@@ -36,7 +46,7 @@ const Select = ({
   label,
   options,
   arrows,
-  hasErrors,
+  haserrors,
   ...props
 }) => {
   const { theme } = useThemeUI()
@@ -117,7 +127,7 @@ const Select = ({
           <ReactSelect
             id={useId()}
             aria-label={label}
-            className={hasErrors && 'error-select'}
+            className={haserrors && 'error-select'}
             styles={customStyles}
             onChange={onChange}
             options={options}

--- a/src/Questions/Input/index.js
+++ b/src/Questions/Input/index.js
@@ -51,7 +51,7 @@ const QuestionInput = ({ question, useForm, component }) => {
         type={question.type}
         placeholder={question.placeholder}
         defaultValue={question.defaultValue}
-        hasErrors={!!errors[question.name]}
+        haserrors={errors[question.name] ? 'true' : 'false'}
         {...register(question.name, {
           ...question.registerConfig,
           pattern: new RegExp(question.registerConfig.pattern)

--- a/src/Questions/Select/index.js
+++ b/src/Questions/Select/index.js
@@ -64,7 +64,7 @@ const QuestionSelect = ({ question, useForm, component, ...props }) => {
           registerConfig={question.registerConfig}
           label={question.label}
           arrows={question.config?.arrows}
-          hasErrors={!!errors[question.name]}
+          haserrors={errors[question.name] ? 'true' : 'false'}
           {...props}
         >
           {question.config &&

--- a/src/builder.js
+++ b/src/builder.js
@@ -72,6 +72,7 @@ const FormBuilder = ({
         </div>
       ),
       input: <QuestionInput useForm={useFormObj} question={question} />,
+      password: <QuestionInput useForm={useFormObj} question={question} />,
       textarea: <QuestionTextarea useForm={useFormObj} question={question} />,
       select: (
         <>


### PR DESCRIPTION
### Type:

- [ ] CI/CD: helm, docker & CI/CD adjustments.
- [x] feature: new capabilities.
- [x] fix: bug, hotfix, etc.
- [ ] refactor: enhancements.
- [ ] style: changes in styles.
- [ ] other: docs, tests.

### What's the focus of this PR:

- Added handling of the `password` type in the form builder.
- When installing the library, the `hasErrors` property was causing warnings due to React complaining about custom properties not being allowed to use camelCase format. It was also complaining about custom properties being not allowed to receive boolean values, having to switch to "true"/"false" strings as per the recommendation.
- Also added the `alt` property to images.

### How to review this PR:

- Your can run the example and check that the Password field masks the characters:

<img width="1440" alt="image" src="https://github.com/onebeyond/react-form-builder/assets/23655224/7cb96ed2-cda1-45a0-8bc0-a9d1ab9aa384">

### Related work items

- [This](https://csmdigital.atlassian.net/browse/CSM-3140) is the Sign In task that need a password field.
- The warnings didn't have a task, but this is how they show in the Dazn project:

<img width="1440" alt="image" src="https://github.com/onebeyond/react-form-builder/assets/23655224/95e1ac92-da48-47ea-ba05-0f46a1ace714">

### Before submitting this PR, I made sure:

- [x] There is no lint error in the code
- [x] Build process passes successfully
- [x] There are some tests
