### PR TITLE
Fix/Not reading haserrors boolean

### DIFF
--- a/src/Fields/Input/index.js
+++ b/src/Fields/Input/index.js
@@ -5,12 +5,9 @@ import { Input as InputUI, jsx } from 'theme-ui'
 import React from 'react'
 
 const Input = React.forwardRef(({ ...props }, ref) => {
+  const { 'data-haserrors': haserrors } = props
   return (
-    <InputUI
-      ref={ref}
-      {...props}
-      className={props.haserrors && 'error-input'}
-    />
+    <InputUI ref={ref} {...props} className={haserrors ? 'error-input' : ''} />
   )
 })
 

--- a/src/Fields/Select/index.js
+++ b/src/Fields/Select/index.js
@@ -46,7 +46,7 @@ const Select = ({
   label,
   options,
   arrows,
-  haserrors,
+  'data-haserrors': haserrors,
   ...props
 }) => {
   const { theme } = useThemeUI()
@@ -127,7 +127,7 @@ const Select = ({
           <ReactSelect
             id={useId()}
             aria-label={label}
-            className={haserrors && 'error-select'}
+            className={haserrors ? 'error-select' : ''}
             styles={customStyles}
             onChange={onChange}
             options={options}

--- a/src/Questions/Input/index.js
+++ b/src/Questions/Input/index.js
@@ -51,7 +51,7 @@ const QuestionInput = ({ question, useForm, component }) => {
         type={question.type}
         placeholder={question.placeholder}
         defaultValue={question.defaultValue}
-        haserrors={errors[question.name] ? 1 : 0}
+        data-haserrors={!!errors[question.name]}
         {...register(question.name, {
           ...question.registerConfig,
           pattern: new RegExp(question.registerConfig.pattern)

--- a/src/Questions/Input/index.js
+++ b/src/Questions/Input/index.js
@@ -51,7 +51,7 @@ const QuestionInput = ({ question, useForm, component }) => {
         type={question.type}
         placeholder={question.placeholder}
         defaultValue={question.defaultValue}
-        haserrors={!!errors[question.name]}
+        haserrors={errors[question.name] ? 1 : 0}
         {...register(question.name, {
           ...question.registerConfig,
           pattern: new RegExp(question.registerConfig.pattern)

--- a/src/Questions/Input/index.js
+++ b/src/Questions/Input/index.js
@@ -51,7 +51,7 @@ const QuestionInput = ({ question, useForm, component }) => {
         type={question.type}
         placeholder={question.placeholder}
         defaultValue={question.defaultValue}
-        haserrors={errors[question.name] ? 'true' : 'false'}
+        haserrors={!!errors[question.name]}
         {...register(question.name, {
           ...question.registerConfig,
           pattern: new RegExp(question.registerConfig.pattern)

--- a/src/Questions/Select/index.js
+++ b/src/Questions/Select/index.js
@@ -64,7 +64,7 @@ const QuestionSelect = ({ question, useForm, component, ...props }) => {
           registerConfig={question.registerConfig}
           label={question.label}
           arrows={question.config?.arrows}
-          haserrors={errors[question.name] ? 'true' : 'false'}
+          haserrors={!!errors[question.name]}
           {...props}
         >
           {question.config &&

--- a/src/Questions/Select/index.js
+++ b/src/Questions/Select/index.js
@@ -64,7 +64,7 @@ const QuestionSelect = ({ question, useForm, component, ...props }) => {
           registerConfig={question.registerConfig}
           label={question.label}
           arrows={question.config?.arrows}
-          haserrors={errors[question.name] ? 1 : 0}
+          data-haserrors={!!errors[question.name]}
           {...props}
         >
           {question.config &&

--- a/src/Questions/Select/index.js
+++ b/src/Questions/Select/index.js
@@ -64,7 +64,7 @@ const QuestionSelect = ({ question, useForm, component, ...props }) => {
           registerConfig={question.registerConfig}
           label={question.label}
           arrows={question.config?.arrows}
-          haserrors={!!errors[question.name]}
+          haserrors={errors[question.name] ? 1 : 0}
           {...props}
         >
           {question.config &&


### PR DESCRIPTION
### Type:

- [ ] CI/CD: helm, docker & CI/CD adjustments.
- [ ] feature: new capabilities.
- [x] fix: bug, hotfix, etc.
- [ ] refactor: enhancements.
- [ ] style: changes in styles.
- [ ] other: docs, tests.

### What's the focus of this PR:

- This PR uses numbers instead of strings to both identify whether there were errors or not, while avoiding warnings due to using booleans in a custom property.

### How to review this PR:

- These are the non-error/error styles showing before and after submitting the form. The third screenshot shows there are no warnings:

<img width="1440" alt="Captura de Pantalla 2023-06-23 a las 9 43 24" src="https://github.com/onebeyond/react-form-builder/assets/23655224/090caf13-3422-4e62-8a5c-97babda08a20">

<img width="1440" alt="Captura de Pantalla 2023-06-23 a las 9 43 48" src="https://github.com/onebeyond/react-form-builder/assets/23655224/4b4c8b5d-1f45-4130-b80c-565d41de62d1">

<img width="1440" alt="Captura de Pantalla 2023-06-23 a las 9 44 01" src="https://github.com/onebeyond/react-form-builder/assets/23655224/07472f9e-5698-49a9-bb94-fa28760d1cdd">

### Related work items

### Before submitting this PR, I made sure:

- [x] There is no lint error in the code
- [x] Build process passes successfully
- [x] There are some tests
