### PR TITLE
Feat/Label links and field descriptions

### DIFF
--- a/example/src/forms.json
+++ b/example/src/forms.json
@@ -153,7 +153,7 @@
               "value": "inverter_compressor"
             },
             {
-              "label": "Energy level",
+              "label": "Energy level ([what's this](https://www.google.com))",
               "value": "energy_level"
             },
             {
@@ -207,6 +207,47 @@
               "value": "prefer_not_to_say"
             }
           ]
+        }
+      },
+      {
+        "name": "tax_code",
+        "type": "input",
+        "label": "[Tax code](https://www.google.com)",
+        "placeholder": "Tax code",
+        "errorMessages": {
+          "required": "This field is required"
+        },
+        "registerConfig": {
+          "required": true
+        }
+      },
+      {
+        "name": "select_with_link",
+        "type": "select",
+        "label": "Have you ever visited [Google](https://www.google.com)?",
+        "placeholder": "Have you?",
+        "config": {
+          "options": [
+            {
+              "label": "Yes",
+              "value": "yes"
+            },
+            {
+              "label": "No",
+              "value": "no"
+            }
+          ]
+        }
+      },
+      {
+        "name": "checkbox_with_link",
+        "type": "checkbox",
+        "label": "External [link](https://www.google.com)",
+        "errorMessages": {
+          "required": "This field is required"
+        },
+        "registerConfig": {
+          "required": true
         }
       }
     ],

--- a/example/src/forms.json
+++ b/example/src/forms.json
@@ -98,6 +98,10 @@
         "errorMessages": {
           "required": "This field is required"
         },
+        "descriptions": [
+          "Password must be 8-20 characters long",
+          "Contain at least 1 number, 1 letter and 1 special character"
+        ],
         "registerConfig": {
           "required": true
         }

--- a/src/Fields/FieldDescription/index.js
+++ b/src/Fields/FieldDescription/index.js
@@ -1,0 +1,31 @@
+import React from 'react'
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { jsx } from 'theme-ui'
+
+const defaultStyles = {
+  m: 0,
+  mt: '0.25rem',
+  fontSize: '14px',
+  display: 'list-item',
+  listStyle: 'disc inside'
+}
+
+const FieldDescription = React.forwardRef(
+  ({ descriptions, name, ...props }, ref) => {
+    return descriptions.map((description, index) => (
+      <p
+        id={`description_${name}_${index}`}
+        key={`description_${name}_${index}`}
+        className='field-description'
+        ref={ref}
+        sx={{ ...defaultStyles, variant: 'forms.fieldDescription' }}
+        {...props}
+      >
+        {description}
+      </p>
+    ))
+  }
+)
+
+export default FieldDescription

--- a/src/Questions/Input/__tests__/input.test.js
+++ b/src/Questions/Input/__tests__/input.test.js
@@ -8,12 +8,16 @@ import QuestionInput from '../'
 const question = {
   name: 'inputName',
   type: 'input',
-  label: 'input label',
+  label: 'input label with [link](https://www.google.com)',
   placeholder: 'input placeholder',
   icon: {
     name: 'question-circle',
     fill: 'red'
   },
+  descriptions: [
+    'Password must be 8-20 characters long',
+    'Contain at least 1 number, 1 letter and 1 special character'
+  ],
   tooltip: {
     text: 'tooltip text example',
     config: {
@@ -31,12 +35,40 @@ const question = {
 const { result } = renderHook(() => useForm())
 const formMethods = result.current
 
-test('label is displayed', () => {
+test('renders label with markdown', () => {
   const { getByText } = render(
     <QuestionInput question={question} useForm={formMethods} />
   )
 
-  expect(getByText('input label'))
+  expect(getByText('input label with', { exact: false })).toBeTruthy()
+})
+
+test('handles default markdown link', () => {
+  const { getByRole } = render(
+    <QuestionInput question={question} useForm={formMethods} />
+  )
+
+  const markDownLink = getByRole('link')
+  expect(markDownLink.href).toBe('https://www.google.com/')
+  expect(markDownLink.target).toBe('_blank')
+})
+
+test('handles custom markdown link callback', () => {
+  const onLinkOpen = jest.fn()
+  const { getByRole } = render(
+    <QuestionInput
+      question={{
+        ...question,
+        label: 'input label with [link](#somewhere)'
+      }}
+      onLinkOpen={onLinkOpen}
+      useForm={formMethods}
+    />
+  )
+  const markDownLink = getByRole('link')
+  expect(markDownLink.href).toContain('#')
+  fireEvent.click(markDownLink)
+  expect(onLinkOpen).toBeCalledWith('somewhere')
 })
 
 test('icon is displayed', () => {
@@ -134,6 +166,17 @@ test('placeholder is displayed', () => {
   )
 
   expect(getByPlaceholderText('input placeholder'))
+})
+
+test('descriptions are displayed', () => {
+  render(<QuestionInput question={question} useForm={formMethods} />)
+
+  expect(screen.getByText('Password must be 8-20 characters long'))
+  expect(
+    screen.getByText(
+      'Contain at least 1 number, 1 letter and 1 special character'
+    )
+  )
 })
 
 test('error is displayed', () => {

--- a/src/Questions/Input/index.js
+++ b/src/Questions/Input/index.js
@@ -1,6 +1,7 @@
 import ErrorMessage from '../../Fields/Error'
 import Input from '../../Fields/Input'
 import Label from '../../Fields/Label'
+import ReactMarkdown from '../../Fields/Markdown'
 import Icon from '../../Common/Icon/Icon'
 
 /** @jsxRuntime classic */
@@ -13,7 +14,7 @@ const styles = {
   }
 }
 
-const QuestionInput = ({ question, useForm, component }) => {
+const QuestionInput = ({ question, useForm, component, onLinkOpen }) => {
   const {
     formState: { errors },
     register
@@ -29,7 +30,22 @@ const QuestionInput = ({ question, useForm, component }) => {
     >
       <div sx={styles.boxIconStyle}>
         {question.label && (
-          <Label htmlFor={question.name}>{question.label}</Label>
+          <Label
+            htmlFor={question.name}
+            sx={{
+              variant: 'forms.input.label'
+            }}
+          >
+            <ReactMarkdown
+              sx={{
+                alignSelf: 'center',
+                p: { m: '0px' }
+              }}
+              source={question.label}
+              onLinkOpen={onLinkOpen}
+              modalLabel={question.modalLabel}
+            />
+          </Label>
         )}
 
         {question.icon && (

--- a/src/Questions/Input/index.js
+++ b/src/Questions/Input/index.js
@@ -1,4 +1,5 @@
 import ErrorMessage from '../../Fields/Error'
+import FieldDescription from '../../Fields/FieldDescription'
 import Input from '../../Fields/Input'
 import Label from '../../Fields/Label'
 import ReactMarkdown from '../../Fields/Markdown'
@@ -73,6 +74,12 @@ const QuestionInput = ({ question, useForm, component, onLinkOpen }) => {
           pattern: new RegExp(question.registerConfig.pattern)
         })}
       />
+      {question.descriptions && question.descriptions.length > 0 && (
+        <FieldDescription
+          name={question.name}
+          descriptions={question.descriptions}
+        />
+      )}
       {errors[question.name] && errors[question.name].type === 'required' && (
         <ErrorMessage
           name={question.name}

--- a/src/Questions/Select/__tests__/select.test.js
+++ b/src/Questions/Select/__tests__/select.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, renderHook } from '@testing-library/react'
+import { fireEvent, render, renderHook } from '@testing-library/react'
 import selectEvent from 'react-select-event'
 import { useForm } from 'react-hook-form'
 import QuestionSelect from '../'
@@ -10,7 +10,7 @@ window.MutationObserver = MutationObserver
 const question = {
   name: 'gender',
   type: 'select',
-  label: 'What is your gender?',
+  label: 'What is your [gender](https://www.google.com)?',
   placeholder: 'Please make a selection',
   errorMessages: {
     required: 'This field is required'
@@ -54,8 +54,40 @@ test('check if placeholder exists', () => {
   customRender().getByText(question.placeholder)
 })
 
-test('check if label exists', () => {
-  customRender().getByLabelText(question.label)
+test('renders label with markdown', () => {
+  const { getByText } = render(
+    <QuestionSelect question={question} useForm={formMethods} />
+  )
+
+  expect(getByText('What is your ', { exact: false })).toBeTruthy()
+})
+
+test('handles default markdown link', () => {
+  const { getByRole } = render(
+    <QuestionSelect question={question} useForm={formMethods} />
+  )
+
+  const markDownLink = getByRole('link')
+  expect(markDownLink.href).toBe('https://www.google.com/')
+  expect(markDownLink.target).toBe('_blank')
+})
+
+test('handles custom markdown link callback', () => {
+  const onLinkOpen = jest.fn()
+  const { getByRole } = render(
+    <QuestionSelect
+      question={{
+        ...question,
+        label: 'input label with [link](#somewhere)'
+      }}
+      onLinkOpen={onLinkOpen}
+      useForm={formMethods}
+    />
+  )
+  const markDownLink = getByRole('link')
+  expect(markDownLink.href).toContain('#')
+  fireEvent.click(markDownLink)
+  expect(onLinkOpen).toBeCalledWith('somewhere')
 })
 
 test('check if error exists', () => {

--- a/src/Questions/Select/index.js
+++ b/src/Questions/Select/index.js
@@ -5,6 +5,7 @@ import ErrorMessage from '../../Fields/Error'
 import React from 'react'
 import Select from '../../Fields/Select'
 import Label from '../../Fields/Label'
+import ReactMarkdown from '../../Fields/Markdown'
 import { jsx } from 'theme-ui'
 
 const styles = {
@@ -30,7 +31,13 @@ const getOptions = (question) => {
   )
 }
 
-const QuestionSelect = ({ question, useForm, component, ...props }) => {
+const QuestionSelect = ({
+  question,
+  useForm,
+  component,
+  onLinkOpen,
+  ...props
+}) => {
   const {
     formState: { errors },
     control,
@@ -48,7 +55,22 @@ const QuestionSelect = ({ question, useForm, component, ...props }) => {
         }}
       >
         {question.label && (
-          <Label htmlFor={question.name}>{question.label}</Label>
+          <Label
+            htmlFor={question.name}
+            sx={{
+              variant: 'forms.select.label'
+            }}
+          >
+            <ReactMarkdown
+              sx={{
+                alignSelf: 'center',
+                p: { m: '0px' }
+              }}
+              source={question.label}
+              onLinkOpen={onLinkOpen}
+              modalLabel={question.modalLabel}
+            />
+          </Label>
         )}
         <Select
           control={control}


### PR DESCRIPTION
### Type:

- [ ] CI/CD: helm, docker & CI/CD adjustments.
- [x] feature: new capabilities.
- [ ] fix: bug, hotfix, etc.
- [ ] refactor: enhancements.
- [x] style: changes in styles.
- [ ] other: docs, tests.

### What's the focus of this PR:

- Adds the possibility to include links on the labels of Input and Select fields. It uses the same method that is already working for Checkboxes.
- Adds field descriptions to Input fields.

### How to review this PR:

- Links in labels (Checkbox was already working):

<img width="1143" alt="image" src="https://github.com/onebeyond/react-form-builder/assets/23655224/fedda5df-e2c9-4807-85a3-669413988fe0">

- Field descriptions:

<img width="1142" alt="image" src="https://github.com/onebeyond/react-form-builder/assets/23655224/b1db52fa-5772-441d-9746-8c4fc55d12c0">

You can run the example to see it working.

### Related work items

- These changes are required for implementing [this](https://www.figma.com/file/Ed1O2zNd83zei6p5eGKoN8/DAZN-Bet-Italy-v1.0-(130423)?type=design&node-id=1-53&mode=design&t=kzbEKNY7Sxk2RBjH-0) page in Dazn.

### Before submitting this PR, I made sure:

- [x] There is no lint error in the code
- [x] Build process passes successfully
- [x] There are some tests
