### PR TITLE
Feat/Custom input errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,25 @@ import React, { useEffect, useState } from 'react'
 import forms from './forms.json'
 import FormBuilder from 'react-form-builder'
 
+const [formErrors, setFormErrors] = useState()
+
 const onSubmitForm = (data) => {
-    !isLoading &&
-      alert(
-        `You have submitted your form correctly Data: ${'\n'} ${JSON.stringify(
-          data,
-          null,
-          2
-        )}`
-      )
-    setLoading(true)
-    setTimeout(() => {
-      setLoading(false)
-    }, 1000)
+    if (data.password !== data.confirmpassword) {
+      setFormErrors([{ field: 'confirmpassword', type: 'doesNotMatch' }])
+    } else {
+      !isLoading &&
+        alert(
+          `You have submitted your form correctly Data: ${'\n'} ${JSON.stringify(
+            data,
+            null,
+            2
+          )}`
+        )
+      setLoading(true)
+      setTimeout(() => {
+        setLoading(false)
+      }, 1000)
+    }
   }
 
 const Example = () => {
@@ -43,6 +49,7 @@ const Example = () => {
         isoCode='ES'
         onLinkOpen={onLinkOpen}
         isLoading={isLoading}
+        formErrors={formErrors}
       />
   }
 }
@@ -66,7 +73,8 @@ http://guidesmiths-react-form-builder.s3-website.eu-central-1.amazonaws.com/
 |  isoCode      |   Isocode of the country to show as default in phone input |  string     | GB
 |  isMobile      |   A boolean toggle is assigned to check if we are from a mobile port view | boolean    | false
 |  countryAndRegionsData    |  Array of objects with the acronym(s) and the names of the countries that you want to display in the `countrySelect` (see example)   |   Array of objects    | -
-|  onLinkOpen       |  function to be executed when there is a custom link  |  function     | -
+|  onLinkOpen       |  Function to be executed when there is a custom link  |  function     | -
+|  formErrors       |  Array of custom errors associated with specific fields |  Array of objects     | []
 
 
 
@@ -258,9 +266,10 @@ https://user-images.githubusercontent.com/79102959/134897303-817957ba-12d1-4c0c-
 | Option  	| Description  	| Type |   Default	|
 |---	|---	|:---:	|:---:	|
 |   name*	|  Input name  	|  string 	|  - 	|
-|   type*   | Must be `input`| string | - |
+|   type*   | Must be `input` or `password` (which will be masked) | string | - |
 |   label	|  Text shown with the input |  string  	|   ''	|
 |   placeholder    |   Placeholder text to be displayed   |    string       |   ''   |
+|   descriptions    |   Extra information that will show below the field   |    string[]       |   []   |
 | **icon**  |   |  json  |   |
 | name  | Name of the icon that we want to be displayed Opt: ['question-circle'] | string  |    -
 |  fill  | Icon color  | string  | black
@@ -270,6 +279,7 @@ https://user-images.githubusercontent.com/79102959/134897303-817957ba-12d1-4c0c-
 |   **errorMessages**	|    	| json   	|   	|
 |  required      |   Error message to display on submit if the checkbox is not checked and is required |  string     | ''
 | pattern  | Error message to display if there is an error pattern in the input text  |  boolean  | false
+| `customError`  | Error message to display for any other custom errors that will be shown with the `formErrors` property passed to the builder  |  string  | ''
 |  **registerConfig**       |    |  json     |
 | required  | Define if the checkbox is required  |  boolean  | false
 | pattern  | Define the pattern to check the input  |  string  | ""
@@ -309,6 +319,40 @@ Input with pattern control example
 }
 
 ```
+Input with custom error (for example, if the user tries to sign up with an email that has already beeen used)
+```yaml
+{
+  "name": "email",
+  "type": "input",
+  "label": "",
+  "placeholder": "Email Address*",
+  "errorMessages": {
+    "required": "This field is required",
+    "pattern": "Invalid email",
+    "repeatedEmail": "This email has already been registered"
+  },
+  "registerConfig": {
+    "required": true,
+    "pattern": "/^[a-z0-9._%+-]+@[a-z0-9.-]+.[a-z]{2,4}$/"
+  }
+}
+
+```
+
+Input with field descriptions
+```yaml
+{
+  "name": "password",
+  "type": "password",
+  "label": "Password",
+  "placeholder": "Password",
+  "descriptions": [
+    "Password must be 8-20 characters long",
+    "Contain at least 1 number, 1 letter and 1 special character"
+  ]
+}
+```
+
 Input with styled icon
 ```yaml
 {

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx, Link } from 'theme-ui'
@@ -46,6 +47,7 @@ const App = () => {
   const [modalText, setModalText] = useState('')
   const [show, setShow] = useState(false)
   const [isLoading, setLoading] = useState(false)
+  const [formErrors, setFormErrors] = useState()
 
   function onLinkOpen(name) {
     setModalText(forms.contact.textToShow[name])
@@ -122,18 +124,22 @@ const App = () => {
   }
 
   const onSubmitForm = (data) => {
-    !isLoading &&
-      alert(
-        `You have submitted your form correctly Data: ${'\n'} ${JSON.stringify(
-          data,
-          null,
-          2
-        )}`
-      )
-    setLoading(true)
-    setTimeout(() => {
-      setLoading(false)
-    }, 1000)
+    if (data.password !== data.confirmpassword) {
+      setFormErrors([{ field: 'confirmpassword', type: 'doesNotMatch' }])
+    } else {
+      !isLoading &&
+        alert(
+          `You have submitted your form correctly Data: ${'\n'} ${JSON.stringify(
+            data,
+            null,
+            2
+          )}`
+        )
+      setLoading(true)
+      setTimeout(() => {
+        setLoading(false)
+      }, 1000)
+    }
   }
 
   return (
@@ -187,6 +193,7 @@ const App = () => {
         language='en'
         onLinkOpen={onLinkOpen}
         isLoading={isLoading}
+        formErrors={formErrors}
       />
     </>
   )

--- a/example/src/forms.json
+++ b/example/src/forms.json
@@ -107,6 +107,19 @@
         }
       },
       {
+        "name": "confirmpassword",
+        "type": "password",
+        "label": "Confirm password",
+        "placeholder": "Confirm password",
+        "errorMessages": {
+          "required": "This field is required",
+          "doesNotMatch": "The passwords do not match"
+        },
+        "registerConfig": {
+          "required": true
+        }
+      },
+      {
         "name": "refrigerator_features",
         "type": "multiple_checkboxes",
         "label": "What features did you look for when buying your refrigerator? [MC, up to 10]",

--- a/src/Questions/Input/index.js
+++ b/src/Questions/Input/index.js
@@ -74,22 +74,19 @@ const QuestionInput = ({ question, useForm, component, onLinkOpen }) => {
           pattern: new RegExp(question.registerConfig.pattern)
         })}
       />
+      {errors[question.name] && errors[question.name].type && (
+        <ErrorMessage
+          name={question.name}
+          message={
+            question.errorMessages &&
+            question.errorMessages[errors[question.name].type]
+          }
+        />
+      )}
       {question.descriptions && question.descriptions.length > 0 && (
         <FieldDescription
           name={question.name}
           descriptions={question.descriptions}
-        />
-      )}
-      {errors[question.name] && errors[question.name].type === 'required' && (
-        <ErrorMessage
-          name={question.name}
-          message={question.errorMessages && question.errorMessages.required}
-        />
-      )}
-      {errors[question.name] && errors[question.name].type === 'pattern' && (
-        <ErrorMessage
-          name={question.name}
-          message={question.errorMessages && question.errorMessages.pattern}
         />
       )}
     </div>

--- a/src/__tests__/builder.test.js
+++ b/src/__tests__/builder.test.js
@@ -11,51 +11,91 @@ window.MutationObserver = MutationObserver
 let component = null
 let mockHandler = null
 
-beforeEach(() => {
-  mockHandler = jest.fn()
-  component = render(
-    <FormBuilder
-      idForm={forms.contact.id}
-      form={forms.contact}
-      isoCode='ES'
-      onSubmit={mockHandler}
-    />
-  )
-})
-
-afterEach(cleanup)
-
-test('check if component is rendered', () => {
-  component.getByText('input label')
-})
-
-test('check if questions are rendered', () => {
-  const allInputs = component.getAllByTestId('question-input')
-  expect(allInputs[0].value).toBe('')
-})
-
-test('check if it calls submit eventhandler once only when required fields are filled in', async () => {
-  const button = component.getByText('Submit')
-  fireEvent.click(button)
-  expect(mockHandler).toHaveBeenCalledTimes(0)
-
-  const inputComponent = component.getAllByTestId('question-input')
-  fireEvent.change(inputComponent[0], { target: { value: 'name testing' } })
-  expect(inputComponent[0].value).toBe('name testing')
-
-  const select = component.getByText('Country')
-  selectEvent.openMenu(select)
-  await fireEvent.keyDown(select, { key: 'Enter', code: 13 })
-  expect(screen.getAllByText('Spain')).toBeTruthy()
-
-  const checkboxes = component.getAllByTestId('question-checkbox')
-  await act(async () => {
-    fireEvent.click(checkboxes[0])
+describe('form builder without custom errors', () => {
+  beforeEach(() => {
+    mockHandler = jest.fn()
+    component = render(
+      <FormBuilder
+        idForm={forms.contact.id}
+        form={forms.contact}
+        isoCode='ES'
+        onSubmit={mockHandler}
+      />
+    )
   })
-  expect(checkboxes[0].checked).toEqual(true)
 
-  await act(async () => {
+  afterEach(cleanup)
+
+  test('check if component is rendered', () => {
+    const input = component.getByText('input label')
+    const description = component.getByText(
+      'Password must be 8-20 characters long'
+    )
+
+    expect(input).not.toBe(null)
+    expect(description).not.toBe(null)
+  })
+
+  test('check if questions are rendered', () => {
+    const allInputs = component.getAllByTestId('question-input')
+    expect(allInputs.length).toBe(3)
+    expect(allInputs[0].value).toBe('')
+    expect(allInputs[1].value).toBe('')
+    expect(allInputs[2].value).toBe('')
+  })
+
+  test('check if it calls submit eventhandler once only when required fields are filled in', async () => {
+    const button = component.getByText('Submit')
     fireEvent.click(button)
+    expect(mockHandler).toHaveBeenCalledTimes(0)
+
+    const inputComponents = component.getAllByTestId('question-input')
+    fireEvent.change(inputComponents[0], { target: { value: 'name testing' } })
+    expect(inputComponents[0].value).toBe('name testing')
+
+    fireEvent.change(inputComponents[1], { target: { value: 'password' } })
+    expect(inputComponents[1].value).toBe('password')
+
+    fireEvent.change(inputComponents[2], { target: { value: 'password' } })
+    expect(inputComponents[2].value).toBe('password')
+
+    const select = component.getByText('Country')
+    selectEvent.openMenu(select)
+    await fireEvent.keyDown(select, { key: 'Enter', code: 13 })
+    expect(screen.getAllByText('Spain')).toBeTruthy()
+
+    const checkboxes = component.getAllByTestId('question-checkbox')
+    await act(async () => {
+      fireEvent.click(checkboxes[0])
+    })
+    expect(checkboxes[0].checked).toEqual(true)
+
+    await act(async () => {
+      fireEvent.click(button)
+    })
+    expect(mockHandler).toHaveBeenCalledTimes(1)
   })
-  expect(mockHandler).toHaveBeenCalledTimes(1)
+})
+
+describe('form builder with custom errors', () => {
+  beforeEach(() => {
+    mockHandler = jest.fn()
+    component = render(
+      <FormBuilder
+        idForm={forms.contact.id}
+        form={forms.contact}
+        isoCode='ES'
+        onSubmit={mockHandler}
+        formErrors={[{ field: 'confirmpassword', type: 'doesNotMatch' }]}
+      />
+    )
+  })
+
+  afterEach(cleanup)
+
+  test('check if component renders custom formErrors', () => {
+    const doesNotMatchError = component.getByText('The passwords do not match')
+
+    expect(doesNotMatchError).not.toBe(null)
+  })
 })

--- a/src/__tests__/forms.json
+++ b/src/__tests__/forms.json
@@ -31,6 +31,35 @@
         }
       },
       {
+        "name": "password",
+        "type": "password",
+        "label": "Password",
+        "placeholder": "Password",
+        "errorMessages": {
+          "required": "This field is required"
+        },
+        "descriptions": [
+          "Password must be 8-20 characters long",
+          "Contain at least 1 number, 1 letter and 1 special character"
+        ],
+        "registerConfig": {
+          "required": true
+        }
+      },
+      {
+        "name": "confirmpassword",
+        "type": "password",
+        "label": "Confirm password",
+        "placeholder": "Confirm password",
+        "errorMessages": {
+          "required": "This field is required",
+          "doesNotMatch": "The passwords do not match"
+        },
+        "registerConfig": {
+          "required": true
+        }
+      },
+      {
         "name": "$Country",
         "placeholder": "Country",
         "priorityOptions": [

--- a/src/builder.js
+++ b/src/builder.js
@@ -43,7 +43,7 @@ const FormBuilder = ({
   onLinkOpen,
   countryAndRegionsData,
   language,
-  formErrors = {},
+  formErrors = [],
   ...props
 }) => {
   const useFormObj = useForm({ defaultValues: { formatDate: '' } })

--- a/src/builder.js
+++ b/src/builder.js
@@ -11,7 +11,7 @@ import QuestionTextarea from './Questions/Textarea'
 import QuestionDate from './Questions/Date'
 import QuestionPhone from './Questions/Phone'
 import QuestionStatic from './Questions/Static'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { jsx } from 'theme-ui'
 import { useForm } from 'react-hook-form'
 import QuestionMultipleCheckboxes from './Questions/MultipleCheckboxes'
@@ -43,9 +43,18 @@ const FormBuilder = ({
   onLinkOpen,
   countryAndRegionsData,
   language,
+  formErrors = {},
   ...props
 }) => {
   const useFormObj = useForm({ defaultValues: { formatDate: '' } })
+
+  useEffect(() => {
+    if (formErrors && formErrors.length > 0) {
+      formErrors.forEach((error) => {
+        useFormObj.setError(error.field, { type: error.type })
+      })
+    }
+  }, [formErrors])
 
   const {
     formState: { errors }


### PR DESCRIPTION
### Type:

- [ ] CI/CD: helm, docker & CI/CD adjustments.
- [x] feature: new capabilities.
- [ ] fix: bug, hotfix, etc.
- [ ] refactor: enhancements.
- [x] style: changes in styles.
- [x] other: docs, tests.

### What's the focus of this PR:

- Add custom errors that can be passed in the `formErrors` property of the builder. This way, we can show errors that happen after submitting the form, not only required/pattern ones.
- Minor fix in field descriptions so they show below any potential errors (looks better).
- Added tests and docs.

### How to review this PR:

- You can run the example and see that after submitting a password that does not match the confirm password, the error shows.

<img width="1174" alt="Captura de Pantalla 2023-07-10 a las 9 44 33" src="https://github.com/onebeyond/react-form-builder/assets/23655224/b5bf39b8-1d91-40f5-85bf-2319c1cb3b73">

### Related work items

- Not a specific task, but it was done for Dazn so errors coming from the backend can be easily shown in relevant fields.

### Before submitting this PR, I made sure:

- [x] There is no lint error in the code
- [x] Build process passes successfully
- [x] There are some tests
