### PR TITLE
Renamed property for default values on MultiCheckboxes

### DIFF
--- a/example/src/forms.json
+++ b/example/src/forms.json
@@ -131,7 +131,7 @@
           "minimumLen": 1,
           "maximumLen": 10
         },
-        "defaultChecked": ["product_net_capacity", "ice_maker"],
+        "defaultCheckedValues": ["product_net_capacity", "ice_maker"],
         "config": {
           "options": [
             {

--- a/src/Questions/MultipleCheckboxes/__tests__/multipleCheckboxes.test.js
+++ b/src/Questions/MultipleCheckboxes/__tests__/multipleCheckboxes.test.js
@@ -14,7 +14,7 @@ const question = {
     maximumLen: 'Maximum choises exceded',
     minimumLen: 'Minimum choises required'
   },
-  defaultChecked: ['three'],
+  defaultCheckedValues: ['three'],
   registerConfig: {
     required: true,
     maximumLen: '2',

--- a/src/Questions/MultipleCheckboxes/index.js
+++ b/src/Questions/MultipleCheckboxes/index.js
@@ -75,7 +75,7 @@ const QuestionMultipleCheckboxes = ({ component, form, question, useForm }) => {
                       aria-describedby={'error_message_' + question.name}
                       name={question.name}
                       value={option.value}
-                      defaultChecked={question.defaultChecked.find(
+                      defaultChecked={question.defaultCheckedValues?.find(
                         (defaultValue) => defaultValue === option.value
                       )}
                       {...register(question.name, {


### PR DESCRIPTION
### Type:

- [ ] CI/CD: helm, docker & CI/CD adjustments.
- [ ] feature: new capabilities.
- [ ] fix: bug, hotfix, etc.
- [x] refactor: enhancements.
- [ ] style: changes in styles.
- [ ] other: docs, tests.

### What's the focus of this PR:

- Rename the default value property for MultiCheckboxes to avoid Contentful confusions.`defaultChecked` for a Checkbox is a boolean, but for a MultiCheckbox is an array of strings.

### How to review this PR:

### Related work items

### Before submitting this PR, I made sure:

- [x] There is no lint error in the code
- [x] Build process passes successfully
- [x] There are some tests
