### PR TITLE
ci: fix release tag creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/@onebeyond/react-form-builder" target="_blank"><img src="https://img.shields.io/npm/v/@onebeyond/react-form-builder.svg?style=flat-square" alt="NPM version" /></a>
   <a href="https://www.npmjs.com/package/@onebeyond/react-form-builder" target="_blank"><img src="https://img.shields.io/npm/dm/@onebeyond/react-form-builder.svg?style=flat-square" alt="NPM downloads" /></a>
-  <a href="https://github.com/onebeyond/react-form-builder/actions/workflows/cd.yml" target="_blank"><img src="https://github.com/onebeyond/react-form-builder/actions/workflows/cd.yml/badge.svg" alt="Publish" /></a>
+  <a href="https://github.com/onebeyond/react-form-builder/actions/workflows/release-and-publish.yml" target="_blank"><img src="https://github.com/onebeyond/react-form-builder/actions/workflows/release-and-publish.yml/badge.svg" alt="Publish" /></a>
   <a href="https://codeclimate.com/github/onebeyond/react-form-builder/maintainability"><img src="https://api.codeclimate.com/v1/badges/7be0c6651a4fd019f777/maintainability" /></a>
   <a href="https://codeclimate.com/github/onebeyond/react-form-builder/test_coverage"><img src="https://api.codeclimate.com/v1/badges/7be0c6651a4fd019f777/test_coverage" /></a>
   <a href="https://socket.dev/npm/package/@onebeyond/react-form-builder" target="_blank"><img src="https://socket.dev/api/badge/npm/package/@onebeyond/react-form-builder" alt="socket.dev" /></a>

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -51,6 +51,8 @@
   ],
   "packages": {
     ".": {
+      "component": "@onebeyond/react-form-builder",
+      "releaseType": "node"
     }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The release-please configuration was not taking the package scope (`@onebeyond`) into account when creating the tag and this can give an error because the tag already exists (the one when the package was not scoped).

In order to solve this, I'm following the solution described [here](https://github.com/googleapis/release-please/issues/1528).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
No related issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Avoid problems when creating new tags and they could collision with tags when the package was not scoped.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've done a test in a personal package first(https://github.com/inigomarquinez/howto-release-please/commit/8050ea6d0949402c861491e7a3f37329131ef7c3)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
