### PR TITLE
style: add classname to textarea when it has errors

### DIFF
--- a/example/src/App.jsx
+++ b/example/src/App.jsx
@@ -4,6 +4,8 @@ import { Link, Outlet } from 'react-router-dom'
 import 'react-datepicker/dist/react-datepicker.css'
 import 'react-phone-number-input/style.css'
 
+import './styles.css'
+
 const App = () => {
   return (
     <div style={{ display: 'flex' }}>

--- a/example/src/styles.css
+++ b/example/src/styles.css
@@ -1,0 +1,3 @@
+.error-input {
+  border: 1px solid red !important
+}

--- a/src/Fields/Textarea/index.js
+++ b/src/Fields/Textarea/index.js
@@ -6,10 +6,13 @@ import React, { useState } from 'react'
 
 const Textarea = React.forwardRef(({ ...props }, ref) => {
   const [count, setCount] = useState(0)
+  const { 'data-haserrors': haserrors } = props
+
   return (
     <>
       <TextareaUI
         ref={ref}
+        className={haserrors ? 'error-input' : ''}
         {...props}
         onChange={(e) => {
           if (props.countType === 'word')

--- a/src/Questions/Textarea/index.js
+++ b/src/Questions/Textarea/index.js
@@ -1,3 +1,5 @@
+import { useFormContext } from 'react-hook-form'
+
 import ErrorMessage from '../../Fields/Error'
 import Textarea from '../../Fields/Textarea'
 import Label from '../../Fields/Label'
@@ -13,11 +15,14 @@ const styles = {
   }
 }
 
-const QuestionTextarea = ({ question, useForm }) => {
+const QuestionTextarea = ({ question }) => {
   const {
     register,
     formState: { errors }
-  } = useForm
+  } = useFormContext()
+
+
+
   const defaultRows = 5
   const reg = {
     ...question.registerConfig,
@@ -89,6 +94,7 @@ const QuestionTextarea = ({ question, useForm }) => {
         defaultValue={question.defaultValue}
         maximumLen={question.registerConfig.maximumLen}
         countType={question.registerConfig.countType}
+        data-haserrors={!!errors[question.name]}
         {...register(question.name, reg)}
       />
       {errors[question.name] &&

--- a/src/builder.js
+++ b/src/builder.js
@@ -86,7 +86,7 @@ const FormBuilder = ({
         <QuestionImageInput useForm={useFormObj} question={question} />
       ),
       password: <QuestionInput useForm={useFormObj} question={question} />,
-      textarea: <QuestionTextarea useForm={useFormObj} question={question} />,
+      textarea: <QuestionTextarea question={question} />,
       select: (
         <>
           <QuestionSelect useForm={useFormObj} question={question} />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In order to customize the textarea question when it has errors, it needs to have a specific class name so the user can customize the style.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Be able to customize the Textarea question when it has errors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using the example app.

## Screenshots (if appropriate):
<img width="569" alt="Captura de pantalla 2024-04-10 a las 13 36 17" src="https://github.com/onebeyond/react-form-builder/assets/25435858/c33f5bb9-ba80-4567-b646-d085fd2a8c9f">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
