### PR TITLE
fix: improve multi-checkbox to disabled when selected option with a true disableOthers

### DIFF
--- a/src/Questions/MultipleCheckboxes/index.js
+++ b/src/Questions/MultipleCheckboxes/index.js
@@ -8,9 +8,9 @@ import Label from '../../Fields/Label'
 
 import ReactMarkdown from 'react-markdown'
 
-const disableOthers = (e) => {
-  Object.entries(e.target.form).forEach(([, v]) => {
-    if (e.target.checked === true) {
+const disableOthers = (option) => (e) => {
+  Object.entries(e?.target?.form || []).forEach(([, v]) => {
+    if (e.target.checked === true && option.value === e.target.value) {
       if (v.type === 'checkbox' && v.name === e.target.name && v !== e.target) {
         v.checked = false
         v.disabled = true
@@ -18,7 +18,7 @@ const disableOthers = (e) => {
       e.target.disabled = false
       e.target.checked = true
     }
-    if (e.target.checked === false) {
+    if (e?.target?.checked === false) {
       if (v.type === 'checkbox' && v.name === e.target.name) {
         v.disabled = false
       }
@@ -71,7 +71,7 @@ const QuestionMultipleCheckboxes = ({ question, useForm }) => {
                     }}
                   >
                     <Checkbox
-                      data-testid="question-singleCheckbox"
+                      data-testid='question-singleCheckbox'
                       id={option.name}
                       aria-describedby={'error_message_' + question.name}
                       name={question.name}
@@ -81,7 +81,7 @@ const QuestionMultipleCheckboxes = ({ question, useForm }) => {
                       )}
                       {...register(question.name, {
                         ...question.registerConfig,
-                        onChange: option.disableOthers && disableOthers,
+                        onChange: option.disableOthers && disableOthers(option),
                         validate: {
                           minimumLen: question.registerConfig.minimumLen
                             ? () =>

--- a/src/Questions/MultipleCheckboxes/index.js
+++ b/src/Questions/MultipleCheckboxes/index.js
@@ -81,7 +81,9 @@ const QuestionMultipleCheckboxes = ({ question, useForm }) => {
                       )}
                       {...register(question.name, {
                         ...question.registerConfig,
-                        onChange: option.disableOthers && disableOthers(option),
+                        onChange: option.disableOthers
+                          ? disableOthers(option)
+                          : undefined,
                         validate: {
                           minimumLen: question.registerConfig.minimumLen
                             ? () =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Send option on disableOthers to allow forcing the disabling of elements only when disableOthers is explicitly enabled.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This problem was detected on client project, where implementing the disableOthers functionality

## How Has This Been Tested?
Tested locally importing the updated library into package.json 

## Screenshots (if appropriate):
Before fix
https://github.com/user-attachments/assets/50f81edb-0c6f-4dba-86e6-68418d81cef5

After fix
https://github.com/user-attachments/assets/ad720907-60c3-43a3-920c-04fbb9e994b9




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
